### PR TITLE
feat(Popup): add role and tabindex for a11y

### DIFF
--- a/packages/vant/src/popup/Popup.tsx
+++ b/packages/vant/src/popup/Popup.tsx
@@ -145,6 +145,8 @@ export default defineComponent({
             duration={props.duration}
             customStyle={props.overlayStyle}
             onClick={onClickOverlay}
+            role={props.closeOnClickOverlay ? 'button' : undefined}
+            tabindex={props.closeOnClickOverlay ? 0 : undefined}
           />
         );
       }
@@ -185,6 +187,8 @@ export default defineComponent({
           v-show={props.show}
           ref={popupRef}
           style={style.value}
+          role="dialog"
+          tabindex={0}
           class={[
             bem({
               round,

--- a/packages/vant/src/popup/Popup.tsx
+++ b/packages/vant/src/popup/Popup.tsx
@@ -144,9 +144,9 @@ export default defineComponent({
             zIndex={zIndex.value}
             duration={props.duration}
             customStyle={props.overlayStyle}
-            onClick={onClickOverlay}
             role={props.closeOnClickOverlay ? 'button' : undefined}
             tabindex={props.closeOnClickOverlay ? 0 : undefined}
+            onClick={onClickOverlay}
           />
         );
       }


### PR DESCRIPTION
If the Popup content area does not have a cancel button, It is necessary to tell the device where to cancel the Popup.