### PR TITLE
性能优化: 减少不必要的rerender

### DIFF
--- a/packages/vant/src/button/Button.tsx
+++ b/packages/vant/src/button/Button.tsx
@@ -112,7 +112,7 @@ export default defineComponent({
       }
     });
 
-    const getStyle = () => {
+    const getStyle = computed(() => {
       const { color, plain } = props;
       if (color) {
         const style: CSSProperties = {
@@ -133,7 +133,7 @@ export default defineComponent({
 
         return style;
       }
-    };
+    });
 
     const onClick = (event: MouseEvent) => {
       if (props.loading) {
@@ -181,7 +181,7 @@ export default defineComponent({
         <tag
           type={nativeType}
           class={classes}
-          style={getStyle()}
+          style={getStyle.value}
           disabled={disabled}
           onClick={onClick}
         >

--- a/packages/vant/src/button/Button.tsx
+++ b/packages/vant/src/button/Button.tsx
@@ -3,6 +3,7 @@ import {
   type PropType,
   type CSSProperties,
   type ExtractPropTypes,
+  computed,
 } from 'vue';
 
 // Utils
@@ -78,7 +79,7 @@ export default defineComponent({
       );
     };
 
-    const renderIcon = () => {
+    const renderIcon = computed(() => {
       if (props.loading) {
         return renderLoadingIcon();
       }
@@ -96,9 +97,9 @@ export default defineComponent({
           />
         );
       }
-    };
+    });
 
-    const renderText = () => {
+    const renderText = computed(() => {
       let text;
       if (props.loading) {
         text = props.loadingText;
@@ -109,7 +110,7 @@ export default defineComponent({
       if (text) {
         return <span class={bem('text')}>{text}</span>;
       }
-    };
+    });
 
     const getStyle = () => {
       const { color, plain } = props;
@@ -185,9 +186,9 @@ export default defineComponent({
           onClick={onClick}
         >
           <div class={bem('content')}>
-            {iconPosition === 'left' && renderIcon()}
-            {renderText()}
-            {iconPosition === 'right' && renderIcon()}
+            {iconPosition === 'left' && renderIcon.value}
+            {renderText.value}
+            {iconPosition === 'right' && renderIcon.value}
           </div>
         </tag>
       );


### PR DESCRIPTION
renderIcon 依赖于 props.icon
renderText 依赖于props.loadingText
比如, 如果props.loadingText变化,  
之前renderIcon 和renderText 都会rerender
现在就只有renderText 会rerender了