### PR TITLE
fix(Popup&Toast): invalid adaptive width

### DIFF
--- a/packages/vant/src/popup/index.less
+++ b/packages/vant/src/popup/index.less
@@ -27,7 +27,7 @@
       top: 50%;
       left: 0;
       right: 0;
-      margin: auto;
+      margin: 0 auto;
       transform: translateY(-50%);
 
       &.van-popup--round {

--- a/packages/vant/src/popup/index.less
+++ b/packages/vant/src/popup/index.less
@@ -25,8 +25,10 @@
 
     &--center {
       top: 50%;
-      left: 50%;
-      transform: translate3d(-50%, -50%, 0);
+      left: 0;
+      right: 0;
+      margin: auto;
+      transform: translateY(-50%);
 
       &.van-popup--round {
         border-radius: var(--van-popup-round-border-radius);


### PR DESCRIPTION
### 修复Popup的position为center时宽度问题:
1.目前的垂直居中方式会导致内容宽度自适应时，最大只能达到50%的宽度
2.同时也导致了Toast会有同样的问题，并且--van-toast-max-width失效

