### PR TITLE
fix: 卡片添加 overflow:auto

### DIFF
--- a/packages/vant-cli/site/desktop/components/Content.vue
+++ b/packages/vant-cli/site/desktop/components/Content.vue
@@ -90,6 +90,7 @@ export default {
   background-color: #fff;
   border-radius: @van-doc-border-radius;
   box-shadow: 0 8px 12px #ebedf0;
+  overflow: auto;
 
   > pre code {
     position: relative;


### PR DESCRIPTION
packages/vant-cli/site/desktop/components/Content.vue

站点卡片添加 overflow:auto，避免缩小浏览器窗口时，介绍页核心团队卡片内头像列表超出。