### PR TITLE
fix(utils): avoid getting unexpected value

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,7 +30,7 @@ export function get(object: any, path: string): any {
   let result = object;
 
   keys.forEach((key) => {
-    result = result[key] ?? '';
+    result = isObject(result) ? result[key] ?? '' : '';
   });
 
   return result;


### PR DESCRIPTION
For example, when calling `get({}, 'button.small')`, it expects to return an empty string, but return a function (`''.small` is a native function, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/small).
