### PR TITLE
chore: remove *.less from sideEffects

### DIFF
--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -68,8 +68,7 @@
   "sideEffects": [
     "es/**/style/*",
     "lib/**/style/*",
-    "*.css",
-    "*.less"
+    "*.css"
   ],
   "web-types": "lib/web-types.json"
 }


### PR DESCRIPTION
Vant 4 on longer publish less files, so the sideEffects of less is not used any more.